### PR TITLE
Calling UnityWebRequest.Dispose()

### DIFF
--- a/Assets/Scenes/AppsflyerSteamModule.cs
+++ b/Assets/Scenes/AppsflyerSteamModule.cs
@@ -296,6 +296,7 @@ public class AppsflyerSteamModule
                 Debug.Log("error details: " + uwr.downloadHandler.text);
             }
         }
+		uwr.Dispose();
     }
 
     // generate GUID for post request and AF id


### PR DESCRIPTION
Fixes "A Native Collection has not been disposed, resulting in a memory leak. Enable Full StackTraces to get more details." errors due to UnityWebRequest not getting disposed.